### PR TITLE
Version and dependencies bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ from distutils.core import setup
 
 setup(
     name='docker-image-patcher',
-    version='0.1.0',
+    version='0.2.0',
     description='',
     author='Sebastian Lohff',
     author_email='sebastian.lohff@sap.com',
     url='https://github.com/sapcc/docker-image-patcher',
     python_requires='>=3.5',
     packages=['docker_image_patcher'],
-    install_requires=['fs', 'docker'],
+    install_requires=['fs', 'docker>=7.1.0', 'requests>=2.32.0'],
     classifiers=[
         'Programming Language :: Python :: 3',
         'Environment :: Console',


### PR DESCRIPTION
Updating to requests>=2.32.0 requires docker>=7.1.0 which in turn
required commit 7aa80d5b6f09f8d49db6cda2e7db5f5f3a282e1 in #2

This PR
- adds requests and docker-py versions in requirements,
- bumps image-patcher version to 0.2.0

The current image-patcher is incompatible with older docker-py versions
and requests>=2.32.0 needs at least 7.1.0.

Also adding requests version to make sure its compatible, as docker-py
requirements only states requests>=2.26.0 in its pyproject.toml