### PR TITLE
Handle docker not running without stacktrace

### DIFF
--- a/docker_image_patcher/docker_image_patch.py
+++ b/docker_image_patcher/docker_image_patch.py
@@ -185,7 +185,11 @@ def main():
     # fetch original values from base image
     if not args.quiet:
         print("Pulling {} ...".format(args.base_image))
-    client = docker.from_env()
+    try:
+        client = docker.from_env()
+    except Exception as e:
+        print(f"Error: Could not reach docker daemon - is it running? Error was: {e}")
+        sys.exit(1)
     try:
         docker_base_image = client.images.pull(args.base_image)
     except docker.errors.NotFound as e:


### PR DESCRIPTION
When the docker daemon is not running, docker.from_env() just errors out with an exception that reports Connection refused / FileNotFound (due to the docker unix domain socket not existing - depending on the connection method and operating system chosen by the user). To better tell the user what's going on we now just report that we couldn't reach the docker daemon and report a string representation of the exception - that should be enough to debug the problem and also should not confuse users as much (as the stacktrace looks a bit like something unexpected happened).

Error looks now like this:

Error: Could not reach docker daemon - is it running? Error was: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(111, 'Connection refused'))